### PR TITLE
CLOUD-3886: Support key value properties in JOB_OUTPUT_PROP_FILE

### DIFF
--- a/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractProcessJob.java
+++ b/azkaban-common/src/main/java/azkaban/jobExecutor/AbstractProcessJob.java
@@ -236,11 +236,15 @@ public abstract class AbstractProcessJob extends AbstractJob {
       final String content = Streams.asString(reader).trim();
 
       if (!content.isEmpty()) {
-        final Map<String, Object> propMap =
-            (Map<String, Object>) JSONUtils.parseJSONFromString(content);
+        try {
+          final Map<String, Object> propMap =
+                  (Map<String, Object>) JSONUtils.parseJSONFromString(content);
 
-        for (final Map.Entry<String, Object> entry : propMap.entrySet()) {
-          outputProps.put(entry.getKey(), entry.getValue().toString());
+          for (final Map.Entry<String, Object> entry : propMap.entrySet()) {
+            outputProps.put(entry.getKey(), entry.getValue().toString());
+          }
+        } catch (Exception tryAsProperties) {
+          return new Props(null, outputPropertiesFile);
         }
       }
       return outputProps;


### PR DESCRIPTION
@HendrikCrause This is same as the other one but much less change and leaves the deprecated method